### PR TITLE
Update macOS version for release workflow

### DIFF
--- a/.github/workflows/release_sample_app.yml
+++ b/.github/workflows/release_sample_app.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release-new-sample-app-version:
-    runs-on: macos-13
+    runs-on: macos-15
 
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change; main risk is unexpected build/signing/toolchain differences on the newer macOS runner.
> 
> **Overview**
> Updates the `release_sample_app.yml` GitHub Actions workflow to run the sample-app release job on `macos-15` instead of `macos-13`, aligning the release pipeline with a newer macOS runner/Xcode environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257424242a8aab024c8ab329243fae670aa3dcf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->